### PR TITLE
Fix expection when image has only one iptc tag.

### DIFF
--- a/src/com/icafe4j/util/ArrayUtils.java
+++ b/src/com/icafe4j/util/ArrayUtils.java
@@ -909,7 +909,7 @@ public class ArrayUtils
 
     public static byte[] subArray(byte[] src, int offset, int len) {
 		if(offset == 0 && len == src.length) return src;
-		if((offset < 0 || offset >= src.length) || (offset + len > src.length))
+		if((offset < 0 || offset > src.length) || (offset + len > src.length))
 			throw new IllegalArgumentException("Copy range out of array bounds");
 		byte[] dest = new byte[len];
 		System.arraycopy(src, offset, dest, 0, len);


### PR DESCRIPTION
When image has only one iptc tag offset == src.length. It is a valid case, but exception is thrown when reading metadata.