### PR TITLE
Add maven build (fixes #83)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,21 +1,27 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion> 
+  <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.dragon66</groupId>
   <artifactId>icafe</artifactId>
   <version>1.1-SNAPSHOT</version>
-  <packaging>jar</packaging> 
+  <packaging>jar</packaging>
   <name>ICAFE Java image library</name>
   <url>https://github.com/dragon66/icafe</url>
+  <properties>
+    <jdk.version>java18</jdk.version>
+    <java.version>1.8</java.version>
+    <targetJdk>${java.version}</targetJdk>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
   <repositories>
-      <repository>
-	  	<id>jai-imageio</id>
-	  	<name>Java Advanced Imaging for ImageIO</name>
-	  	<url>http://maven.geotoolkit.org</url>
-	  	<releases>
-	  	    <enabled>true</enabled>
-	  	</releases> 
-	  </repository> 
+    <repository>
+      <id>jai-imageio</id>
+      <name>Java Advanced Imaging for ImageIO</name>
+      <url>http://maven.geotoolkit.org</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+    </repository>
   </repositories>
   <dependencies>
       <dependency>
@@ -29,4 +35,45 @@
 		<version>1.7.12</version>
       </dependency>
   </dependencies>
+  <build>
+    <sourceDirectory>src</sourceDirectory>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+          <excludes>
+            <exclude>**/document/**</exclude>
+            <exclude>**/game/**</exclude>
+            <exclude>**/graphics/**</exclude>
+            <exclude>**/processing/**</exclude>
+            <exclude>**/scripting/**</exclude>
+            <exclude>**/test/**</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+            </execution>
+        </executions>
+      </plugin>
+    </plugins>
+    <resources>
+      <resource>
+        <directory>src</directory>
+        <includes>
+          <include>log4j.properties</include>
+          <include>resources/CMYK Profiles/USWebCoatedSWOP.icc</include>
+        </includes>
+      </resource>
+    </resources>
+  </build>
 </project>


### PR DESCRIPTION
The maven build can be run using: `mvn clean install` and outputs to `target`. This includes building the source jar, so that IDEs can resolve that during debugging.

This change makes the dependency available on Jitpack. It will build the commit on-demand (fixed, branch, or snapshot) and cache the results. This way the dependency can be sourced without you needing to push a new build.

For example, to fetch the build ([log](https://jitpack.io/com/github/ben-manes/icafe/d04fe36e71/build.log)) from my fork would require users adding:

```xml
<repository>
  <id>jitpack.io</id>
  <url>https://jitpack.io</url>
</repository>
```
```xml
<dependency>
  <groupId>com.github.ben-manes</groupId>
  <artifactId>icafe</artifactId>
  <version>-SNAPSHOT</version>
</dependency>
```