### PR TITLE
dependecy changed to com.github.jai-imageiodependecy changed to com.g…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.dragon66</groupId>
   <artifactId>icafe</artifactId>
@@ -13,27 +13,17 @@
     <targetJdk>${java.version}</targetJdk>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
-  <repositories>
-    <repository>
-      <id>jai-imageio</id>
-      <name>Java Advanced Imaging for ImageIO</name>
-      <url>http://maven.geotoolkit.org</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-    </repository>
-  </repositories>
   <dependencies>
-      <dependency>
-		<groupId>javax.media</groupId>
-		<artifactId>jai_imageio</artifactId>
-		<version>1.1</version>
-	  </dependency>
-      <dependency>
-	    <groupId>org.slf4j</groupId>
-		<artifactId>slf4j-api</artifactId>
-		<version>1.7.12</version>
-      </dependency>
+    <dependency>
+      <groupId>com.github.jai-imageio</groupId>
+      <artifactId>jai-imageio-core</artifactId>
+      <version>1.3.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.12</version>
+    </dependency>
   </dependencies>
   <build>
     <sourceDirectory>src</sourceDirectory>
@@ -59,10 +49,10 @@
         <executions>
           <execution>
             <id>attach-sources</id>
-              <goals>
-                <goal>jar</goal>
-              </goals>
-            </execution>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
         </executions>
       </plugin>
     </plugins>


### PR DESCRIPTION
…ithub.jai-imageio

maven compiles again

Still I'm not sure if something else broke as I'm not too deep into this.

There are no tests executed with maven.

For my use (writing methadata to png files) it works.

In order to make our CI/CD run again it would be nice if there would be a merge in near future.